### PR TITLE
Create a catch all route endpoint

### DIFF
--- a/lib/diaryAPI_web/controllers/catch_all_controller.ex
+++ b/lib/diaryAPI_web/controllers/catch_all_controller.ex
@@ -1,0 +1,25 @@
+defmodule DiaryAPIWeb.CatchAllController do
+  use DiaryAPIWeb, :controller
+
+  def match_invalid_routes(conn, _params) do
+    router_module = DiaryAPIWeb.Router
+    routes = Phoenix.Router.routes(router_module)
+    # route_info = Enum.filter(routes, &route_info_fn/1)
+
+    conn
+    |> put_status(404)
+    |> json(%{
+      "message" => "Endpoint not found, check list of available routes",
+      "routes" => routes |> Enum.map(&route_info_fn/1) |> Enum.filter(&(&1 != nil))
+    })
+  end
+
+  defp route_info_fn(route_data) do
+    if route_data.verb != :* do
+      %{
+        method: route_data.verb |> Atom.to_string() |> String.upcase(),
+        path: route_data.path
+      }
+    end
+  end
+end

--- a/lib/diaryAPI_web/router.ex
+++ b/lib/diaryAPI_web/router.ex
@@ -45,4 +45,9 @@ defmodule DiaryAPIWeb.Router do
       forward "/mailbox", Plug.Swoosh.MailboxPreview
     end
   end
+
+  scope "/", DiaryAPIWeb do
+    pipe_through :api
+    match :*, "/*path", CatchAllController, :match_invalid_routes
+  end
 end


### PR DESCRIPTION
**What does this PR do?**
It returns a json with all the endpoints the API have (a mini documentation) should a client make an API call with the wrong method or wrong endpoint